### PR TITLE
バージョン情報の重複を削除

### DIFF
--- a/.agent.md
+++ b/.agent.md
@@ -36,7 +36,6 @@ This is a Python package trial project designed for testing PyPI registration. T
 ### Version Management
 - Update version numbers in `pyproject.toml` when making changes
 - Follow semantic versioning (MAJOR.MINOR.PATCH)
-- Current version: 0.0.1
 
 ### Testing Guidelines
 - Create test files in a `tests/` directory if adding comprehensive testing


### PR DESCRIPTION
## 変更内容\n\n- ファイルからの記述を削除\n\n## 理由\n\n- 複数のファイルにバージョン情報があると管理が難しくなる\n- バージョン情報はで一元管理する