### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   quick-tests:
     name: Quick Tests


### PR DESCRIPTION
Potential fix for [https://github.com/zenjiro/package-trial/security/code-scanning/18](https://github.com/zenjiro/package-trial/security/code-scanning/18)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions` blocks. Since the workflow does not require write access, we will set `contents: read` as the minimal permission. This change ensures that the `GITHUB_TOKEN` has only the necessary permissions, reducing the risk of misuse.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
